### PR TITLE
FixPythonReleaseTest: Add a sleep to let the pypi index update

### DIFF
--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -49,6 +49,7 @@ ARG PYTHON_RELEASE_VERSION
 COPY ./tests /src/tests
 COPY ./ci/run-tests.sh /src/ci/run-tests.sh
 RUN true && \
+    sleep 30 \
     pip install alchemy-logging==${PYTHON_RELEASE_VERSION} && \
     ./ci/run-tests.sh ./tests/test_alog.py && \
     true


### PR DESCRIPTION
Looks like trying to immediately pip install the release will fail to find
the newly published version