### PR TITLE
Lazy formatter 64

### DIFF
--- a/src/ts/README.md
+++ b/src/ts/README.md
@@ -141,6 +141,28 @@ All log functions have several required and optional components:
     }
     ```
 
+### Lazy Logging
+
+The `alog` framework is designed to enable low-level logging without incurring performance hits. To support this, you can use lazy log creation to only perform message creation if the given channel and level are enabled. This can be done by creating a `MessageGenerator`. A `MessageGenerator` is a function that takes no arguments and produces a `string`. For example:
+
+```ts
+function expensiveStringCreation() {
+    ...
+    return someString;
+}
+alog.info('CHANL', expensiveStringCreation);
+```
+
+In this example, the `expensiveStringCreation` function will only be invoked if the `CHANL` channel is enabled at the `info` level.
+
+The most common expensive log creation is done with standard [Template Literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals). While expanding a template literal is not terribly expensive for high-level logs, if logs are added to low-level functions, they can add up. The `alog.fmt` function acts as a [Tag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) to keep common template literal syntax while leveraging lazy `MessageGenerator`s. For example:
+
+```ts
+largeArray.forEach((element: any) => {
+    alog.debug4('CHANL', alog.fmt`The element is ${element}`);
+});
+```
+
 ## Utilities
 
 ### Global Metadata

--- a/src/ts/src/alog.ts
+++ b/src/ts/src/alog.ts
@@ -30,7 +30,7 @@ import { AlogCoreSingleton } from './core';
 
 // Pass-Through exports
 export { configure } from './configure';
-export { JsonFormatter, PrettyFormatter } from './formatters';
+export { JsonFormatter, PrettyFormatter, fmt } from './formatters';
 export {
   AlogConfig,
   AlogConfigError,

--- a/src/ts/src/formatters.ts
+++ b/src/ts/src/formatters.ts
@@ -33,6 +33,7 @@ import {
   FATAL,
   FormatterFunc,
   INFO,
+  MessageGenerator,
   TRACE,
   WARNING,
 } from './types';
@@ -117,4 +118,20 @@ export function JsonFormatter(record: any): string {
 export const defaultFormatterMap: {[key: string]: FormatterFunc} = {
   pretty: PrettyFormatter,
   json: JsonFormatter,
+}
+
+/** @brief The fmt function is a tagged template that lazily creates a message
+ * generator
+ *
+ * This function is syntatic sugar around creating a MessageGenerator to perform
+ * lazy logging. It takes advantage of the Tagged Template feature of node to
+ * act as a Templat Literal Tag. For example:
+ *
+ * const val: number = 1;
+ * alog.debug('CHAN', alog.fmt`The value is ${val}`);
+ *
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates
+ */
+export function fmt(template: TemplateStringsArray, ...substitutions: any[]): MessageGenerator {
+  return () => String.raw(template, ...substitutions);
 }

--- a/src/ts/test/api_test.ts
+++ b/src/ts/test/api_test.ts
@@ -193,6 +193,15 @@ describe('Alog Typescript Public API Test Suite', () => {
     });
   }); // log functions
 
+  describe('fmt', () => {
+    it('should produce a lazy message generator', () => {
+      const val: number = 1;
+      const gen: alog.MessageGenerator = alog.fmt`The value is ${val}`;
+      expect(typeof gen).to.equal('function');
+      expect(gen()).to.equal(`The value is ${val}`);
+    });
+  });
+
   describe('indentation', () => {
 
     let logStream: Writable;


### PR DESCRIPTION
## Description

This PR adds the `alog.fmt` [Template Literal Tag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) to cleanly support lazy logging.

## Changes

* Add the `alog.fmt` function
* Add a unit test
* Add a README section

## Testing

Unit test coverage

## Related Issue(s)

https://github.com/IBM/alchemy-logging/issues/64

**NOTE**: This PR will have a conflict in the `README` with https://github.com/IBM/alchemy-logging/pull/68. I kept them separate so that merge order will be independent, but whichever comes second will need a rebase.
