### PR TITLE
[ts] Explicit core log functions

### DIFF
--- a/src/ts/src/alog.ts
+++ b/src/ts/src/alog.ts
@@ -65,13 +65,13 @@ export const removeMetadata = AlogCoreSingleton.getInstance().removeMetadata;
 export const resetOutputStreams = AlogCoreSingleton.getInstance().resetOutputStreams;
 
 // Add all of the level functions
-export const fatal = (AlogCoreSingleton.getInstance() as any).fatal;
-export const error = (AlogCoreSingleton.getInstance() as any).error;
-export const warning = (AlogCoreSingleton.getInstance() as any).warning;
-export const info = (AlogCoreSingleton.getInstance() as any).info;
-export const trace = (AlogCoreSingleton.getInstance() as any).trace;
-export const debug = (AlogCoreSingleton.getInstance() as any).debug;
-export const debug1 = (AlogCoreSingleton.getInstance() as any).debug1;
-export const debug2 = (AlogCoreSingleton.getInstance() as any).debug2;
-export const debug3 = (AlogCoreSingleton.getInstance() as any).debug3;
-export const debug4 = (AlogCoreSingleton.getInstance() as any).debug4;
+export const fatal = AlogCoreSingleton.getInstance().fatal;
+export const error = AlogCoreSingleton.getInstance().error;
+export const warning = AlogCoreSingleton.getInstance().warning;
+export const info = AlogCoreSingleton.getInstance().info;
+export const trace = AlogCoreSingleton.getInstance().trace;
+export const debug = AlogCoreSingleton.getInstance().debug;
+export const debug1 = AlogCoreSingleton.getInstance().debug1;
+export const debug2 = AlogCoreSingleton.getInstance().debug2;
+export const debug3 = AlogCoreSingleton.getInstance().debug3;
+export const debug4 = AlogCoreSingleton.getInstance().debug4;

--- a/src/ts/src/channel-log.ts
+++ b/src/ts/src/channel-log.ts
@@ -24,7 +24,7 @@
 
 // Local
 import { AlogCoreSingleton } from './core';
-import { LogMetadata, MessageGenerator } from './types';
+import { LogCode, Loggable, LogMetadata } from './types';
 
 /**
  * The ChannelLog object binds a channel name and wraps all of the core
@@ -42,94 +42,134 @@ export class ChannelLog {
 
   /*-- Log Functions --*/
 
+  // Log to fatal
+  public fatal(message: Loggable, metadata?: LogMetadata): void;
+  public fatal(logCode: LogCode, message?: Loggable, metadata?: LogMetadata): void;
   public fatal(
-    channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().fatal(this.channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().fatal(
+      this.channel, codeOrMsg as string, msgOrMeta as Loggable, meta,
+    );
   }
 
+  // Log to error
+  public error(message: Loggable, metadata?: LogMetadata): void;
+  public error(logCode: LogCode, message?: Loggable, metadata?: LogMetadata): void;
   public error(
-    channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().error(this.channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().error(
+      this.channel, codeOrMsg as string, msgOrMeta as Loggable, meta,
+    );
   }
 
+  // Log to warning
+  public warning(message: Loggable, metadata?: LogMetadata): void;
+  public warning(logCode: LogCode, message?: Loggable, metadata?: LogMetadata): void;
   public warning(
-    channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().warning(this.channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().warning(
+      this.channel, codeOrMsg as string, msgOrMeta as Loggable, meta,
+    );
   }
 
+  // Log to info
+  public info(message: Loggable, metadata?: LogMetadata): void;
+  public info(logCode: LogCode, message?: Loggable, metadata?: LogMetadata): void;
   public info(
-    channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().info(this.channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().info(
+      this.channel, codeOrMsg as string, msgOrMeta as Loggable, meta,
+    );
   }
 
+  // Log to trace
+  public trace(message: Loggable, metadata?: LogMetadata): void;
+  public trace(logCode: LogCode, message?: Loggable, metadata?: LogMetadata): void;
   public trace(
-    channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().trace(this.channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().trace(
+      this.channel, codeOrMsg as string, msgOrMeta as Loggable, meta,
+    );
   }
 
+  // Log to debug
+  public debug(message: Loggable, metadata?: LogMetadata): void;
+  public debug(logCode: LogCode, message?: Loggable, metadata?: LogMetadata): void;
   public debug(
-    channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().debug(this.channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().debug(
+      this.channel, codeOrMsg as string, msgOrMeta as Loggable, meta,
+    );
   }
 
+  // Log to debug1
+  public debug1(message: Loggable, metadata?: LogMetadata): void;
+  public debug1(logCode: LogCode, message?: Loggable, metadata?: LogMetadata): void;
   public debug1(
-    channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().debug1(this.channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().debug1(
+      this.channel, codeOrMsg as string, msgOrMeta as Loggable, meta,
+    );
   }
 
+  // Log to debug2
+  public debug2(message: Loggable, metadata?: LogMetadata): void;
+  public debug2(logCode: LogCode, message?: Loggable, metadata?: LogMetadata): void;
   public debug2(
-    channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().debug2(this.channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().debug2(
+      this.channel, codeOrMsg as string, msgOrMeta as Loggable, meta,
+    );
   }
 
+  // Log to debug3
+  public debug3(message: Loggable, metadata?: LogMetadata): void;
+  public debug3(logCode: LogCode, message?: Loggable, metadata?: LogMetadata): void;
   public debug3(
-    channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().debug3(this.channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().debug3(
+      this.channel, codeOrMsg as string, msgOrMeta as Loggable, meta,
+    );
   }
 
+  // Log to debug4
+  public debug4(message: Loggable, metadata?: LogMetadata): void;
+  public debug4(logCode: LogCode, message?: Loggable, metadata?: LogMetadata): void;
   public debug4(
-    channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().debug4(this.channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().debug4(
+      this.channel, codeOrMsg as string, msgOrMeta as Loggable, meta,
+    );
   }
 
   /*-- Helper Functions --*/

--- a/src/ts/src/channel-log.ts
+++ b/src/ts/src/channel-log.ts
@@ -24,6 +24,7 @@
 
 // Local
 import { AlogCoreSingleton } from './core';
+import { LogMetadata, MessageGenerator } from './types';
 
 /**
  * The ChannelLog object binds a channel name and wraps all of the core
@@ -32,44 +33,103 @@ import { AlogCoreSingleton } from './core';
 export class ChannelLog {
 
   public channel: string;
-  private coreInstance: any;
+  private coreInstance: AlogCoreSingleton;
 
   constructor(channel: string) {
     this.channel = channel;
-    this.coreInstance = AlogCoreSingleton.getInstance() as any;
+    this.coreInstance = AlogCoreSingleton.getInstance();
   }
 
   /*-- Log Functions --*/
 
-  public fatal(...args: any[]): void {
-    this.coreInstance.fatal(this.channel, ...args);
+  public fatal(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().fatal(this.channel, argThree, argFour, argFive);
   }
-  public error(...args: any[]): void {
-    this.coreInstance.error(this.channel, ...args);
+
+  public error(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().error(this.channel, argThree, argFour, argFive);
   }
-  public warning(...args: any[]): void {
-    this.coreInstance.warning(this.channel, ...args);
+
+  public warning(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().warning(this.channel, argThree, argFour, argFive);
   }
-  public info(...args: any[]): void {
-    this.coreInstance.info(this.channel, ...args);
+
+  public info(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().info(this.channel, argThree, argFour, argFive);
   }
-  public trace(...args: any[]): void {
-    this.coreInstance.trace(this.channel, ...args);
+
+  public trace(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().trace(this.channel, argThree, argFour, argFive);
   }
-  public debug(...args: any[]): void {
-    this.coreInstance.debug(this.channel, ...args);
+
+  public debug(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().debug(this.channel, argThree, argFour, argFive);
   }
-  public debug1(...args: any[]): void {
-    this.coreInstance.debug1(this.channel, ...args);
+
+  public debug1(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().debug1(this.channel, argThree, argFour, argFive);
   }
-  public debug2(...args: any[]): void {
-    this.coreInstance.debug2(this.channel, ...args);
+
+  public debug2(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().debug2(this.channel, argThree, argFour, argFive);
   }
-  public debug3(...args: any[]): void {
-    this.coreInstance.debug3(this.channel, ...args);
+
+  public debug3(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().debug3(this.channel, argThree, argFour, argFive);
   }
-  public debug4(...args: any[]): void {
-    this.coreInstance.debug4(this.channel, ...args);
+
+  public debug4(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().debug4(this.channel, argThree, argFour, argFive);
   }
 
   /*-- Helper Functions --*/

--- a/src/ts/src/core.ts
+++ b/src/ts/src/core.ts
@@ -41,6 +41,8 @@ import {
   FilterMap,
   FormatterFunc,
   INFO,
+  LogCode,
+  Loggable,
   LogMetadata,
   LogRecord,
   MessageGenerator,
@@ -175,102 +177,182 @@ export class AlogCoreSingleton {
 
   // Log to fatal
   public fatal(
+    channel: string, message: Loggable, metadata?: LogMetadata,
+  ): void;
+  public fatal(
+    channel: string, logCode: LogCode, message?: Loggable, metadata?: LogMetadata,
+  ): void;
+  public fatal(
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.fatal, channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().log(
+      AlogCoreSingleton.levelFromName.fatal, channel, codeOrMsg, msgOrMeta, meta,
+    );
   }
 
   // Log to error
   public error(
+    channel: string, message: Loggable, metadata?: LogMetadata,
+  ): void;
+  public error(
+    channel: string, logCode: LogCode, message?: Loggable, metadata?: LogMetadata,
+  ): void;
+  public error(
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.error, channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().log(
+      AlogCoreSingleton.levelFromName.error, channel, codeOrMsg, msgOrMeta, meta,
+    );
   }
 
   // Log to warning
   public warning(
+    channel: string, message: Loggable, metadata?: LogMetadata,
+  ): void;
+  public warning(
+    channel: string, logCode: LogCode, message?: Loggable, metadata?: LogMetadata,
+  ): void;
+  public warning(
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.warning, channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().log(
+      AlogCoreSingleton.levelFromName.warning, channel, codeOrMsg, msgOrMeta, meta,
+    );
   }
 
   // Log to info
   public info(
+    channel: string, message: Loggable, metadata?: LogMetadata,
+  ): void;
+  public info(
+    channel: string, logCode: LogCode, message?: Loggable, metadata?: LogMetadata,
+  ): void;
+  public info(
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.info, channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().log(
+      AlogCoreSingleton.levelFromName.info, channel, codeOrMsg, msgOrMeta, meta,
+    );
   }
 
   // Log to trace
   public trace(
+    channel: string, message: Loggable, metadata?: LogMetadata,
+  ): void;
+  public trace(
+    channel: string, logCode: LogCode, message?: Loggable, metadata?: LogMetadata,
+  ): void;
+  public trace(
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.trace, channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().log(
+      AlogCoreSingleton.levelFromName.trace, channel, codeOrMsg, msgOrMeta, meta,
+    );
   }
 
   // Log to debug
   public debug(
+    channel: string, message: Loggable, metadata?: LogMetadata,
+  ): void;
+  public debug(
+    channel: string, logCode: LogCode, message?: Loggable, metadata?: LogMetadata,
+  ): void;
+  public debug(
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.debug, channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().log(
+      AlogCoreSingleton.levelFromName.debug, channel, codeOrMsg, msgOrMeta, meta,
+    );
   }
 
   // Log to debug1
   public debug1(
+    channel: string, message: Loggable, metadata?: LogMetadata,
+  ): void;
+  public debug1(
+    channel: string, logCode: LogCode, message?: Loggable, metadata?: LogMetadata,
+  ): void;
+  public debug1(
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.debug1, channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().log(
+      AlogCoreSingleton.levelFromName.debug1, channel, codeOrMsg, msgOrMeta, meta,
+    );
   }
 
   // Log to debug2
   public debug2(
+    channel: string, message: Loggable, metadata?: LogMetadata,
+  ): void;
+  public debug2(
+    channel: string, logCode: LogCode, message?: Loggable, metadata?: LogMetadata,
+  ): void;
+  public debug2(
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.debug2, channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().log(
+      AlogCoreSingleton.levelFromName.debug2, channel, codeOrMsg, msgOrMeta, meta,
+    );
   }
 
   // Log to debug3
   public debug3(
+    channel: string, message: Loggable, metadata?: LogMetadata,
+  ): void;
+  public debug3(
+    channel: string, logCode: LogCode, message?: Loggable, metadata?: LogMetadata,
+  ): void;
+  public debug3(
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.debug3, channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().log(
+      AlogCoreSingleton.levelFromName.debug3, channel, codeOrMsg, msgOrMeta, meta,
+    );
   }
 
   // Log to debug4
   public debug4(
+    channel: string, message: Loggable, metadata?: LogMetadata,
+  ): void;
+  public debug4(
+    channel: string, logCode: LogCode, message?: Loggable, metadata?: LogMetadata,
+  ): void;
+  public debug4(
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
-    argFive?: LogMetadata,
-  ): void {
-    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.debug4, channel, argThree, argFour, argFive);
+    codeOrMsg: LogCode|Loggable,
+    msgOrMeta?: Loggable|LogMetadata,
+    meta?: LogMetadata,
+  ) {
+    AlogCoreSingleton.getInstance().log(
+      AlogCoreSingleton.levelFromName.debug4, channel, codeOrMsg, msgOrMeta, meta,
+    );
   }
 
   //////////////////////////////
@@ -301,23 +383,23 @@ export class AlogCoreSingleton {
   //
   // @param level: The level to emit the log at
   // @param channel: The channel to log on
-  // @param argThree: This can be one of several things:
+  // @param msgOrMeta: This can be one of several things:
   //  * log code - Add that to the record as the log_code
   //  * string - Just log it
   //  * MessageGenerator - Lazy generator for the message
   //  * LogMetadata - Key value map of metadata objects
-  // @param argFour: This can be one of several things:
-  //  * string - If argThree is a log code, this is the message
-  //  * MessageGenerator - If argThree is a log code, this is a generator for
+  // @param meta: This can be one of several things:
+  //  * string - If msgOrMeta is a log code, this is the message
+  //  * MessageGenerator - If msgOrMeta is a log code, this is a generator for
   //      the message
   //  * LogMetadata - Metadata for the call
-  // @param argFive: If argThree is a log code and argFour is either a string or
+  // @param argFive: If msgOrMeta is a log code and meta is either a string or
   //  a MessageGenerator, this can be extra metadata for the call
   private log(
     level: number,
     channel: string,
-    argThree: string|MessageGenerator|LogMetadata,
-    argFour?: string|MessageGenerator|LogMetadata,
+    msgOrMeta: Loggable|LogMetadata,
+    meta?: Loggable|LogMetadata,
     argFive?: LogMetadata,
   ): void {
 
@@ -343,35 +425,35 @@ export class AlogCoreSingleton {
       }
 
       // Determine if the first variable arg is a log code
-      if (AlogCoreSingleton.isLogCode(argThree)) {
-        record.log_code = argThree as string;
+      if (AlogCoreSingleton.isLogCode(msgOrMeta)) {
+        record.log_code = msgOrMeta as string;
 
-        if (typeof argFour === 'function') {
+        if (typeof meta === 'function') {
           // Signature 1
           // log(channel: string, logCode: string, message?: MessageGenerator, metadata?: LogRecord)
-          record.message = argFour() as string;
-        } else if (typeof argFour === 'string') {
+          record.message = meta() as string;
+        } else if (typeof meta === 'string') {
           // Signature 2
           // log(channel: string, logCode: string, message?: string, metadata?: LogRecord)
-          record.message = argFour as string;
-        } // else ignore argFour because it's invalid
+          record.message = meta as string;
+        } // else ignore meta because it's invalid
         if (argFive !== undefined && Object.keys(argFive).length) {
           record.metadata = Object.assign((record.metadata || {}), deepCopy(argFive));
         }
 
       } else {
 
-        if (typeof argThree === 'function') {
+        if (typeof msgOrMeta === 'function') {
           // Signature 3
           // log(channel: string, message?: MessageGenerator, metadata?: LogRecord)
-          record.message = argThree() as string;
-        } else if (typeof argThree === 'string')  {
+          record.message = msgOrMeta() as string;
+        } else if (typeof msgOrMeta === 'string')  {
           // Signature 4
           // log(channel: string, message?: string, metadata?: LogRecord)
-          record.message = argThree as string;
-        } // else ignore argThree because it's invalid
-        if (argFour !== undefined && typeof argFour === 'object' && Object.keys(argFour).length) {
-          record.metadata = Object.assign((record.metadata || {}), deepCopy(argFour));
+          record.message = msgOrMeta as string;
+        } // else ignore msgOrMeta because it's invalid
+        if (meta !== undefined && typeof meta === 'object' && Object.keys(meta).length) {
+          record.metadata = Object.assign((record.metadata || {}), deepCopy(meta));
         }
       }
 

--- a/src/ts/src/core.ts
+++ b/src/ts/src/core.ts
@@ -114,19 +114,6 @@ export class AlogCoreSingleton {
   // Private constructor
   private constructor() {
     this.reset();
-
-    // Add log functions for each level
-    for (const levelName of Object.keys(AlogCoreSingleton.levelFromName)) {
-      if (levelName !== 'off') {
-        (this as any)[levelName] = (
-          channel: string,
-          argThree: string|MessageGenerator|LogMetadata,
-          argFour?: string|MessageGenerator|LogMetadata,
-          argFive?: LogMetadata) => {
-          this.log(AlogCoreSingleton.levelFromName[levelName], channel, argThree, argFour, argFive);
-        }
-      }
-    }
   }
 
   /////////////////////////////
@@ -184,6 +171,106 @@ export class AlogCoreSingleton {
       AlogCoreSingleton.getInstance().filters[channel] ||
       AlogCoreSingleton.getInstance().defaultLevel);
     return level >= enabledLevel;
+  }
+
+  // Log to fatal
+  public fatal(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.fatal, channel, argThree, argFour, argFive);
+  }
+
+  // Log to error
+  public error(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.error, channel, argThree, argFour, argFive);
+  }
+
+  // Log to warning
+  public warning(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.warning, channel, argThree, argFour, argFive);
+  }
+
+  // Log to info
+  public info(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.info, channel, argThree, argFour, argFive);
+  }
+
+  // Log to trace
+  public trace(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.trace, channel, argThree, argFour, argFive);
+  }
+
+  // Log to debug
+  public debug(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.debug, channel, argThree, argFour, argFive);
+  }
+
+  // Log to debug1
+  public debug1(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.debug1, channel, argThree, argFour, argFive);
+  }
+
+  // Log to debug2
+  public debug2(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.debug2, channel, argThree, argFour, argFive);
+  }
+
+  // Log to debug3
+  public debug3(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.debug3, channel, argThree, argFour, argFive);
+  }
+
+  // Log to debug4
+  public debug4(
+    channel: string,
+    argThree: string|MessageGenerator|LogMetadata,
+    argFour?: string|MessageGenerator|LogMetadata,
+    argFive?: LogMetadata,
+  ): void {
+    AlogCoreSingleton.getInstance().log(AlogCoreSingleton.levelFromName.debug4, channel, argThree, argFour, argFive);
   }
 
   //////////////////////////////

--- a/src/ts/src/types.ts
+++ b/src/ts/src/types.ts
@@ -50,6 +50,12 @@ export type FormatterFunc = (logRecord: LogRecord) => string;
 // The type for a lazy record generator
 export type MessageGenerator = () => string;
 
+// The type used for a log code
+export type LogCode = string;
+
+// The type that defines something which can be logged
+export type Loggable = string|MessageGenerator;
+
 export interface AlogConfig {
   defaultLevel: number;
   filters?: FilterMap;

--- a/src/ts/test/internals_test.ts
+++ b/src/ts/test/internals_test.ts
@@ -42,77 +42,77 @@ describe('Alog TypeScript Internals Test Suite', () => {
       });
 
       it('should be able to set the default level', () => {
-        expect((alogCore as any).defaultLevel).to.equal(alog.OFF);
+        expect(alogCore.defaultLevel).to.equal(alog.OFF);
         alogCore.setDefaultLevel(alog.DEBUG);
-        expect((alogCore as any).defaultLevel).to.equal(alog.DEBUG);
+        expect(alogCore.defaultLevel).to.equal(alog.DEBUG);
       });
 
       it('should be able to set filters', () => {
-        expect((alogCore as any).defaultLevel).to.equal(alog.OFF);
+        expect(alogCore.defaultLevel).to.equal(alog.OFF);
         alogCore.setFilters({TEST: alog.INFO});
-        expect((alogCore as any).filters).to.deep.equal({TEST: alog.INFO});
+        expect(alogCore.filters).to.deep.equal({TEST: alog.INFO});
       });
 
       it('should be able to set the formatter', () => {
-        expect((alogCore as any).formatter.name).to.equal(PrettyFormatter.name);
+        expect(alogCore.formatter.name).to.equal(PrettyFormatter.name);
         alogCore.setFormatter(JsonFormatter);
-        expect((alogCore as any).formatter.name).to.equal(JsonFormatter.name);
+        expect(alogCore.formatter.name).to.equal(JsonFormatter.name);
       });
 
       it('should be able to indent', () => {
-        expect((alogCore as any).numIndent).to.equal(0);
+        expect(alogCore.numIndent).to.equal(0);
         alogCore.indent();
-        expect((alogCore as any).numIndent).to.equal(1);
+        expect(alogCore.numIndent).to.equal(1);
       });
 
       it('should be able to deindent', () => {
-        expect((alogCore as any).numIndent).to.equal(0);
+        expect(alogCore.numIndent).to.equal(0);
         alogCore.indent();
-        expect((alogCore as any).numIndent).to.equal(1);
+        expect(alogCore.numIndent).to.equal(1);
         alogCore.deindent();
-        expect((alogCore as any).numIndent).to.equal(0);
+        expect(alogCore.numIndent).to.equal(0);
       });
 
       it('should be not able to deindent past 0', () => {
-        expect((alogCore as any).numIndent).to.equal(0);
+        expect(alogCore.numIndent).to.equal(0);
         alogCore.deindent();
-        expect((alogCore as any).numIndent).to.equal(0);
+        expect(alogCore.numIndent).to.equal(0);
       });
 
       it('should be able to add metadata', () => {
-        expect((alogCore as any).metadata).to.deep.equal({});
+        expect(alogCore.metadata).to.deep.equal({});
         alogCore.addMetadata('key', {nested: 1});
-        expect((alogCore as any).metadata).to.deep.equal({key: {nested: 1}});
+        expect(alogCore.metadata).to.deep.equal({key: {nested: 1}});
       });
 
       it('should be able to remove metadata', () => {
-        expect((alogCore as any).metadata).to.deep.equal({});
+        expect(alogCore.metadata).to.deep.equal({});
         alogCore.addMetadata('key', {nested: 1});
-        expect((alogCore as any).metadata).to.deep.equal({key: {nested: 1}});
+        expect(alogCore.metadata).to.deep.equal({key: {nested: 1}});
         alogCore.removeMetadata('key');
-        expect((alogCore as any).metadata).to.deep.equal({});
+        expect(alogCore.metadata).to.deep.equal({});
       });
 
       it('should ignore request to remove unknown metadata', () => {
-        expect((alogCore as any).metadata).to.deep.equal({});
+        expect(alogCore.metadata).to.deep.equal({});
         alogCore.addMetadata('key', {nested: 1});
-        expect((alogCore as any).metadata).to.deep.equal({key: {nested: 1}});
+        expect(alogCore.metadata).to.deep.equal({key: {nested: 1}});
         alogCore.removeMetadata('foobar');
-        expect((alogCore as any).metadata).to.deep.equal({key: {nested: 1}});
+        expect(alogCore.metadata).to.deep.equal({key: {nested: 1}});
       });
 
       it('should be able to add a custom stream', () => {
-        expect((alogCore as any).streams.length).to.equal(1);
+        expect(alogCore.streams.length).to.equal(1);
         alogCore.addOutputStream(new MemoryStreams.WritableStream());
-        expect((alogCore as any).streams.length).to.equal(2);
+        expect(alogCore.streams.length).to.equal(2);
       });
 
       it('should be able to reset output streams', () => {
-        expect((alogCore as any).streams.length).to.equal(1);
+        expect(alogCore.streams.length).to.equal(1);
         alogCore.addOutputStream(new MemoryStreams.WritableStream());
-        expect((alogCore as any).streams.length).to.equal(2);
+        expect(alogCore.streams.length).to.equal(2);
         alogCore.resetOutputStreams();
-        expect((alogCore as any).streams.length).to.equal(1);
+        expect(alogCore.streams.length).to.equal(1);
       });
     }); // mutators
 


### PR DESCRIPTION
## Description

This PR moves from programmatically defining the per-level logging functions on the `AlogCoreSingleton` to explicitly defining them to make `TypeScript` play nicer.

## Changes

* Explicitly define all level log functions on `AlogCoreSingleton`
* Explicitly define all level log function arguments on `ChannelLog`
* Remove casting with `as any`

## Testing

All unit tests still pass

