### PR TITLE
FixTsReleaseTest: Fix release test imports for module refactor

### DIFF
--- a/src/ts/Dockerfile
+++ b/src/ts/Dockerfile
@@ -45,7 +45,8 @@ COPY ./test /src/test
 RUN true && \
     ([ "$RELEASE_DRY_RUN" != "true" ] && sleep 30 || true) && \
     sed -i'' 's,alchemy-logging,test-alchemy-logging,g' package.json && \
-    sed -i'' 's,../src,alchemy-logging,g' test/*.ts && \
+    sed -i'' 's,../src/,alchemy-logging/dist/,g' test/*.ts && \
+    sed -i'' "s,../src',alchemy-logging',g" test/*.ts && \
     npm install alchemy-logging@${TS_RELEASE_VERSION} && \
     npm test && \
     true


### PR DESCRIPTION
## Description

This test fixes how the unit tests are run against the installed module in the `release_test` phase

## Changes

* Fix the sed replaces to get the module names correct

## Testing

```sh
docker build . \
  --build-arg RELEASE_DRY_RUN=true \
  --build-arg TS_RELEASE_VERSION=1.2.0 \
  --build-arg NPM_TOKEN=XXXXXX \
  --target release_test
```

