### PR TITLE
Python import configure 99

### DIFF
--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -402,6 +402,16 @@ def _parse_str_of_filters(filters):
             logging.warning("Invalid filter entry [%s]", entry)
     return chan_map
 
+## Import-time Setup ###########################################################
+
+# Add custom low levels
+for level, name in g_alog_level_to_name.items():
+    if name not in ["off", "notset"]:
+        _add_level_fn(name, level)
+
+# Patch over isEnabledFor to support level names
+_add_is_enabled()
+
 ## Core ########################################################################
 
 def configure(
@@ -470,14 +480,6 @@ def configure(
     handler = handler_generator()
     handler.setFormatter(g_alog_formatter)
     logging.root.addHandler(handler)
-
-    # Add custom low levels
-    for level, name in g_alog_level_to_name.items():
-        if name not in ["off", "notset"]:
-            _add_level_fn(name, level)
-
-    # Patch over isEnabledFor to support level names
-    _add_is_enabled()
 
     # Set default level
     default_level_val = g_alog_name_to_level.get(default_level, None)
@@ -752,8 +754,3 @@ def timed_function(log_fn, format_str="", *fmt_args):
                 return func(*args, **kwargs)
         return wrapper
     return decorator
-
-# Run a static configure when first imported to ensure that all custom logging
-# configuration (including function names) is available before user-provided
-# configure is called.
-configure("off")

--- a/src/python/tests/test_alog.py
+++ b/src/python/tests/test_alog.py
@@ -286,7 +286,7 @@ class TestThreadId(unittest.TestCase):
         # Log a sample message
         test_channel.info('This is a test')
 
-        # run in subprocess and capture stderr
+        # Capture the output and make sure the thread id is present
         logged_output = capture_formatter.get_json_records()
         self.assertEqual(len(logged_output), 1)
         self.assertIn('thread_id', logged_output[0])
@@ -302,7 +302,7 @@ class TestThreadId(unittest.TestCase):
         # Log a sample message
         test_channel.info('This is a test')
 
-        # run in subprocess and capture stderr
+        # Capture the output and make sure the thread id is present
         self.assertTrue(len(capture_formatter.captured), 1)
         logged_output = capture_formatter.get_pretty_records()[0]
         self.assertIn('thread_id', logged_output)

--- a/src/python/tests/test_alog_clean_import.py
+++ b/src/python/tests/test_alog_clean_import.py
@@ -22,7 +22,12 @@
 # SOFTWARE.
 ################################################################################
 
-# Import the implementation details so that we can test them
+# Standard
+import logging
+import io
+import re
+
+# Local
 import alog
 
 def test_log_before_configure():
@@ -31,3 +36,41 @@ def test_log_before_configure():
     """
     ch = alog.use_channel("TEST")
     ch.debug2("No throw")
+
+
+def test_default_log_configuration_works():
+    '''We need to run this in a process that has a clean set of imports so that
+    we can evaluate the import behavior. Using importlib.reload in the main
+    process does not actually rerun the import-time code in alog.
+    '''
+    # Set up some standard logging with custom formatting
+    log_stream = io.StringIO()
+    stream_handler = logging.StreamHandler(stream=log_stream)
+    fmt = '%(asctime)s [%(levelname)s] %(message)s'
+    logging.basicConfig(
+        level=logging.INFO,
+        format=fmt,
+        handlers=[stream_handler],
+    )
+
+    # NOTE: This really sucks, but it seems to be impossible to get pytest to
+    #   not pre-configure the logging package, so we have to override the config
+    #   for the child logger explicitly. This is NOT necessary when running the
+    #   content of this test in a plain vanilla python session, but since pytest
+    #   does some configuration of its own before the test starts, the above
+    #   basicConfig call doesn't override that configuration.
+    logger = logging.getLogger('mychan')
+    logger.setLevel(logging.INFO)
+    logger.addHandler(stream_handler)
+    stream_handler.formatter = logging.Formatter(fmt)
+
+    # Make sure debug2 works
+    logger.debug2('Yep')
+    assert log_stream.getvalue() == ''
+
+    # Log to a standard enabled level and make sure the formatting is right
+    # 2021-11-18 15:16:07,468 [INFO] test123
+    logger.info('message')
+    log_lines = list(filter(lambda x: x, log_stream.getvalue().split('\n')))
+    assert len(log_lines) == 1
+    assert re.match(r'\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d \[INFO\] message', log_lines[0])


### PR DESCRIPTION
## Description

This PR refines the `import` semantics such that the additional log level and `isEnabled` functions are added to the core `Logger` class at `import` time to avoid `AttributeError`, but the core `logging` package is NOT configured at `import` time. This allows packages which use a library that logs with `alog` to perform their own logging configuration without `alog` hijacking the conig.

## Changes

* Changes in `alog.py` to only do the function decoration at `import` time
* New unit test to validate that standard logging config works

## Testing

* Unit test coverage
    * NOTE: This test is a bit wonky because it seems to be impossible to make `pytest` NOT configure the `logging` package. I've validated that the simple version (without needing to override the `logger`'s `handler` directly) works in a clean python interpreter.

## Related Issue(s)

#99 
