### PR TITLE
Boost deps 39

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -36,8 +36,7 @@ install(
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 if (${BUILD_UNIT_TESTS})
 
-  # Find boost and gtest with local package install
-  find_package(Boost REQUIRED COMPONENTS regex)
+  # Find gtest with local package install
   find_package(GTest REQUIRED)
 
   enable_testing()
@@ -51,10 +50,8 @@ if (${BUILD_UNIT_TESTS})
   )
   target_include_directories(${ut_exe_name} PUBLIC tests/include)
   target_include_directories(${ut_exe_name} PUBLIC ${GTEST_INCLUDE_DIRS})
-  target_include_directories(${library_name} PUBLIC ${Boost_INCLUDE_DIRECTORIES})
   target_link_libraries(${ut_exe_name} ${library_name})
   target_link_libraries(${ut_exe_name} ${GTEST_LIBRARIES})
-  target_link_libraries(${ut_exe_name} ${Boost_LIBRARIES})
   target_link_options(${ut_exe_name} PUBLIC "-pthread")
   add_test(${ut_exe_name} "${ut_binary_dir}/${ut_exe_name}")
 endif()

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -21,16 +21,11 @@ CPMAddPackage(
     "JSON_BuildTests OFF"
 )
 
-# Find boost and gtest with local package install
-find_package(Boost REQUIRED COMPONENTS locale regex)
-
 # Add the library
 set(library_name alog)
 add_library(${library_name} src/logger.cpp)
 target_include_directories(${library_name} PUBLIC include)
-target_include_directories(${library_name} PUBLIC ${Boost_INCLUDE_DIRECTORIES})
 target_include_directories(${library_name} PUBLIC ${nlohmann_json_SOURCE_DIR}/single_include)
-target_link_libraries(${library_name} ${Boost_locale_LIBRARIES})
 set_target_properties(alog PROPERTIES PUBLIC_HEADER include/alog/logger.hpp)
 install(
   TARGETS alog
@@ -40,7 +35,11 @@ install(
 # Add the unit tests if enabled
 option(BUILD_UNIT_TESTS "Build the unit tests" ON)
 if (${BUILD_UNIT_TESTS})
+
+  # Find boost and gtest with local package install
+  find_package(Boost REQUIRED COMPONENTS regex)
   find_package(GTest REQUIRED)
+
   enable_testing()
   set(ut_binary_dir ${CMAKE_BINARY_DIR}/bin/test)
   set(ut_exe_name alog_test.ut)
@@ -52,6 +51,7 @@ if (${BUILD_UNIT_TESTS})
   )
   target_include_directories(${ut_exe_name} PUBLIC tests/include)
   target_include_directories(${ut_exe_name} PUBLIC ${GTEST_INCLUDE_DIRS})
+  target_include_directories(${library_name} PUBLIC ${Boost_INCLUDE_DIRECTORIES})
   target_link_libraries(${ut_exe_name} ${library_name})
   target_link_libraries(${ut_exe_name} ${GTEST_LIBRARIES})
   target_link_libraries(${ut_exe_name} ${Boost_LIBRARIES})

--- a/src/cpp/Dockerfile
+++ b/src/cpp/Dockerfile
@@ -17,7 +17,7 @@ RUN true && \
     cmake --version && \
     rm cmake-${CMAKE_VERSION}-linux-x86_64.sh && \
     apt-get update -y && \
-    apt-get install -y libboost-locale-dev libboost-regex-dev libgtest-dev && \
+    apt-get install -y libboost-regex-dev libgtest-dev && \
     apt-get clean autoclean && \
     apt-get autoremove --yes && \
     true

--- a/src/cpp/Dockerfile
+++ b/src/cpp/Dockerfile
@@ -17,7 +17,7 @@ RUN true && \
     cmake --version && \
     rm cmake-${CMAKE_VERSION}-linux-x86_64.sh && \
     apt-get update -y && \
-    apt-get install -y libboost-regex-dev libgtest-dev && \
+    apt-get install -y libgtest-dev && \
     apt-get clean autoclean && \
     apt-get autoremove --yes && \
     true

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -2,7 +2,7 @@
 The `alog` framework provides tunable logging with easy-to-use defaults and power-user capabilities. The mantra of `alog` is **"Log Early And Often"**. To accomplish this goal, `alog` makes it easy to enable verbose logging at develop/debug time and trim the verbosity at production run time.
 
 ## Dependencies
-The `alog` library is intentionally light on dependencies. The only dependencies necessary are [nlohmann/json](hhttps://github.com/nlohmann/json) and [boost/algorithm](https://github.com/boostorg/algorithm/tree/boost-1.69.0) and [boost/locale](https://github.com/boostorg/locale/tree/boost-1.69.0).
+The `alog` library is intentionally light on dependencies. The only dependency necessary is [nlohmann/json](hhttps://github.com/nlohmann/json).
 
 ## Channels and Levels
 The primary components of the system are **channels** and **levels** which allow for each log statement to be enabled or disabled when appropriate.

--- a/src/cpp/src/logger.cpp
+++ b/src/cpp/src/logger.cpp
@@ -26,17 +26,17 @@
 #include "alog/logger.hpp"
 
 // Standard
+#include <chrono>
+#include <codecvt>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 #include <utility>
 #include <vector>
-#include <ctime>
-#include <chrono>
-#include <sstream>
-#include <iostream>
-#include <iomanip>
 
 // Third Party
 #include <boost/algorithm/string/join.hpp>
-#include <boost/locale/encoding_utf.hpp>
 
 namespace logging
 {
@@ -111,9 +111,10 @@ std::string getTimestamp()
 }
 
 // CITE: https://stackoverflow.com/questions/15615136/is-codecvt-not-a-std-header
-std::string wstring_to_utf8(const std::wstring& str)
+std::string wstring_to_utf8 (const std::wstring& str)
 {
-  return boost::locale::conv::utf_to_utf<char>(str.c_str(), str.c_str() + str.size());
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+  return converter.to_bytes(str);
 }
 
 // Helper to transform the keys of a map into a vector for initialization

--- a/src/cpp/src/logger.cpp
+++ b/src/cpp/src/logger.cpp
@@ -35,9 +35,6 @@
 #include <utility>
 #include <vector>
 
-// Third Party
-#include <boost/algorithm/string/join.hpp>
-
 namespace logging
 {
 
@@ -152,7 +149,10 @@ void addPrettyPrintMap(
     {
       std::vector<std::string> lines;
       addPrettyPrintMap(val, a_format, a_indent+1, false, lines);
-      ss << "\n" + boost::algorithm::join(lines, "\n");
+      for (const auto& line : lines)
+      {
+        ss << "\n" << line;
+      }
     }
     else
     {

--- a/src/cpp/tests/logger_test.cpp
+++ b/src/cpp/tests/logger_test.cpp
@@ -23,13 +23,11 @@
  *----------------------------------------------------------------------------*/
 #include "unit_testing.h"
 
+#include <chrono>
+#include <functional>
 #include <regex>
 #include <stdlib.h>
-#include <functional>
-#include <chrono>
 #include <thread>
-
-#include <boost/regex.hpp>
 
 using json = nlohmann::json;
 
@@ -121,9 +119,9 @@ std::shared_ptr<CParsedLogEntry> parseStdLine(const std::string& a_line)
   std::string restOfRegex = "([^\\]]*)\\[([^:]*):([^\\]:]*):?([^\\]\\s]*)\\] ([\\s]*)([^\\s].*)\n?";
   std::stringstream ss;
   ss << "^" << timestampRegex << " " << restOfRegex << "$";
-  boost::regex re(ss.str());
-  boost::smatch m;
-  boost::regex_match(a_line, m, re);
+  std::regex re(ss.str());
+  std::smatch m;
+  std::regex_match(a_line, m, re);
   if (m.size() != 8)
   {
     return {};
@@ -140,9 +138,9 @@ std::shared_ptr<CParsedLogEntry> parseStdLine(const std::string& a_line)
     out->serviceName = m[2];
     if (not out->serviceName.empty())
     {
-      boost::regex snRe("<([^>]*)> ");
-      boost::smatch snM;
-      boost::regex_match(out->serviceName, snM, snRe);
+      std::regex snRe("<([^>]*)> ");
+      std::smatch snM;
+      std::regex_match(out->serviceName, snM, snRe);
       if (snM.size() == 2)
       {
         out->serviceName = snM[1];


### PR DESCRIPTION
## Description

This PR removes the `boost` dependencies for the `c++` implementation

## Changes

* Use `std::regex` instead of `boost::regex` in unit tests
* Use `codecvt` instead of `boost::locale` for converting `std::wstring` to `std::string` w/ `utf8`
* Implement manual string joining instead of `boost::algorithm::join`
* Remove `boost` deps from the `Dockerfile` setup phase
* Remove `boost` library search from the `CMakeLists.txt`

## Testing

All code builds cleanly and unit tests pass with no modification beyond `regex` replacement.

## Related Issue(s)

#39 
