### PR TITLE
TSNullMetadata: Ignore null metadata arguments

### DIFF
--- a/src/ts/src/core.ts
+++ b/src/ts/src/core.ts
@@ -474,7 +474,7 @@ export class AlogCoreSingleton {
           record.message = '';
           record.metadata = Object.assign((record.metadata || {}), deepCopy(msgOrMeta));
         } // else ignore msgOrMeta because it's invalid
-        if (meta !== undefined && typeof meta === 'object' && Object.keys(meta).length) {
+        if (meta !== undefined && meta !== null && typeof meta === 'object' && Object.keys(meta).length) {
           record.metadata = Object.assign((record.metadata || {}), deepCopy(meta));
         }
       }

--- a/src/ts/test/api_test.ts
+++ b/src/ts/test/api_test.ts
@@ -295,6 +295,11 @@ describe('Alog Typescript Public API Test Suite', () => {
       ])).to.be.true;
     });
 
+    it('should handle null metadata', () => {
+      alog.info('TEST', 'foobar', null)
+      alog.info('TEST', 'foobar', undefined)
+    });
+
     /*
     // SCOPED METADATA TESTS
     */


### PR DESCRIPTION
## Description

This addresses the bug in #132

## Changes

* Guard against `null` in the metadata argument

## Testing

* Unit test that exercised the bug (which failed before fix)

## Related Issue(s)

https://github.com/IBM/alchemy-logging/issues/132
