### PR TITLE
Py filename format 152

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,11 +7,43 @@ on:
     branches: [ main ]
   workflow_dispatch: {}
 jobs:
-  build:
+  build-36:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Run unit tests
         run: |
           cd src/python
-          docker build . --target=test
+          docker build . --target=test --build-arg PYTHON_VERSION=3.6
+  build-37:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run unit tests
+        run: |
+          cd src/python
+          docker build . --target=test --build-arg PYTHON_VERSION=3.7
+  build-38:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run unit tests
+        run: |
+          cd src/python
+          docker build . --target=test --build-arg PYTHON_VERSION=3.8
+  build-39:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run unit tests
+        run: |
+          cd src/python
+          docker build . --target=test --build-arg PYTHON_VERSION=3.9
+  build-310:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run unit tests
+        run: |
+          cd src/python
+          docker build . --target=test --build-arg PYTHON_VERSION=3.10

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -2,7 +2,8 @@
 #
 # This phase sets up dependencies for the other phases
 ##
-FROM python:3.6-slim as base
+ARG PYTHON_VERSION=3.6
+FROM python:${PYTHON_VERSION}-slim as base
 
 # This image is only for building, so we run as root
 WORKDIR /src

--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -317,8 +317,11 @@ class _MultiEqualString:
 # This is the _right_ way to de-ailas the wrapper function, but it doesn't
 # work on python 3.6 and 3.7.
 g_log_extra_kwargs = {}
-if sys.version_info >= (3, 8, "", 0):
-    g_log_extra_kwargs["stacklevel"] = 2
+if sys.version_info >= (3, 8, 0, "", 0):
+    # Pop 2 additional levels off the stack:
+    #   - _log_with_code_method_override
+    #   - inline lambda
+    g_log_extra_kwargs["stacklevel"] = 3
 
 # If this is an old version of python, we overwrite logging._srcfile with a
 # _MultiEqualString so that _this_ file will also match True to stack frames

--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -29,8 +29,9 @@ configurable formatting and scoped loggers.
 import functools
 import json
 import logging
-import time
+import sys
 import threading
+import time
 import traceback
 from datetime import datetime, timedelta
 
@@ -299,6 +300,34 @@ g_alog_formatter = None
 # necessary to enable reconfiguring dynamically
 g_filtered_channels = []
 
+class _MultiEqualString:
+    """This 'str' class is used to allow the __eq__ operator to match multiple
+    strings. This is needed for python 3.6 and 3.7 in order to indicate that
+    this file matches True for == when checking if a stack frame matches an
+    "internal" name.
+    """
+    def __init__(self, *strings):
+        self._strings = strings
+
+    def __eq__(self, other):
+        return other in self._strings
+
+# If this is python 3.8+, the _log function has a `stacklevel` argument that
+# can be given to indicate the need to pop additional levels off the stack.
+# This is the _right_ way to de-ailas the wrapper function, but it doesn't
+# work on python 3.6 and 3.7.
+g_log_extra_kwargs = {}
+if sys.version_info >= (3, 8, "", 0):
+    g_log_extra_kwargs["stacklevel"] = 2
+
+# If this is an old version of python, we overwrite logging._srcfile with a
+# _MultiEqualString so that _this_ file will also match True to stack frames
+# from this file. This is "safe" to do as the notion of explicitly setting
+# _srcfile is supported based on the comment here:
+# https://github.com/python/cpython/blob/v3.6.15/Lib/logging/__init__.py#L180
+else:
+    logging._srcfile = _MultiEqualString(logging._srcfile, __file__)
+
 def is_log_code(arg):
     return arg.startswith('<') and arg.endswith('>')
 
@@ -318,17 +347,17 @@ def _log_with_code_method_override(self, value, arg_one, *args, **kwargs):
         return
 
     # If no positional args, arg_one is message
-    elif len(args) == 0:
-        self.log(value, arg_one, **kwargs)
+    if len(args) == 0:
+        self.log(value, arg_one, **g_log_extra_kwargs, **kwargs)
 
     # If arg_one looks like a log code, use the first positional arg as message
     elif is_log_code(arg_one):
         message = args[0] % tuple(args[1:]) if len(args) > 1 else args[0]
-        self.log(value, {"log_code": arg_one, "message": message}, **kwargs)
+        self.log(value, {"log_code": arg_one, "message": message}, **g_log_extra_kwargs, **kwargs)
 
     # Otherwise, treat arg_one as the message
     else:
-        self.log(value, arg_one, *args, **kwargs)
+        self.log(value, arg_one, *args, **g_log_extra_kwargs, **kwargs)
 
 def _add_level_fn(name, value):
     logging.addLevelName(value, name.upper())

--- a/src/python/ci/develop.sh
+++ b/src/python/ci/develop.sh
@@ -4,7 +4,7 @@
 cd $(dirname ${BASH_SOURCE[0]})/..
 
 # Build the base as the develop shell
-docker build . --target=base -t alog-py-develop
+docker build . --target=base -t alog-py-develop $@
 
 # Run with source mounted
 docker run --rm -it -v $PWD:/src --entrypoint /bin/bash -w /src alog-py-develop


### PR DESCRIPTION
## Description

This PR fixes #152 by skipping stack frames from `alog.py` when determining `%(filename)s`, `%(lineno)s`, and `%(funcName)s` in log formatters.

## Changes

* For python versions `3.8`+, set `stacklevel=3` in all `self.log` calls. This is the "right" way to solve it
* For python versions < `3.8`, leverage the [comparison against `_srcfile` in `findCaller`](https://github.com/python/cpython/blob/3.7/Lib/logging/__init__.py#L1460) to skip frames where the filename is `alog.py`
    * This is implemented by creating a `_MultiEqualString` that will compare `==` against multiple strings

## Testing

* Unit test that exercises the given bug
* Tests against different python versions

## Related Issue(s)

#152 
