### PR TITLE
Strict warnings

### DIFF
--- a/src/cpp/Dockerfile
+++ b/src/cpp/Dockerfile
@@ -31,7 +31,7 @@ COPY . /src
 RUN true && \
     mkdir build && \
     cd build && \
-    cmake .. && \
+    cmake .. -D CMAKE_CXX_FLAGS="-Wall -Werror" && \
     make && \
     ctest && \
     make install && \

--- a/src/python/ci/run-tests.sh
+++ b/src/python/ci/run-tests.sh
@@ -9,4 +9,4 @@ python3 -m pytest \
     --cov=util \
     --cov-report=term \
     --cov-report=html \
-    --disable-pytest-warnings "$@"
+    -Werror "$@"

--- a/src/python/tests/test_alog.py
+++ b/src/python/tests/test_alog.py
@@ -363,7 +363,7 @@ class TestLogCode(unittest.TestCase):
         self.assertEqual(record['message'], 'This is a test')
 
         # Make sure the percent encoding in the message was preserved
-        self.assertEquals('https://url.com/a%20b', logged_output[1]['message'])
+        self.assertEqual('https://url.com/a%20b', logged_output[1]['message'])
 
     def test_log_code_arg(self):
         '''Test that logging with the first argument as a log code adds the code

--- a/src/ts/Dockerfile
+++ b/src/ts/Dockerfile
@@ -17,7 +17,7 @@ RUN npm install
 ##
 FROM base as test
 COPY . /src
-RUN npm test
+RUN npm run lint && npm test
 
 ## Release #####################################################################
 #


### PR DESCRIPTION
## Description

Implement strict warnings in the build processes for `python`, `ts`, and `c++` (`go` is _always_ strict!)

## Changes

* `-Werror` in `python`'s test script
* `npm run lint` before `npm test` in `ts` build
* `-Wall -Werror` in c++ build

## Testing

It's all about testing!

## Related Issue(s)

#159 
