### PR TITLE
Format errors without log codes 163

### DIFF
--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -350,7 +350,7 @@ def _log_with_code_method_override(self, value, arg_one, *args, **kwargs):
         return
 
     # If no positional args, arg_one is message
-    if len(args) == 0:
+    if not args:
         self.log(value, arg_one, **g_log_extra_kwargs, **kwargs)
 
     # If arg_one looks like a log code, use the first positional arg as message
@@ -359,8 +359,12 @@ def _log_with_code_method_override(self, value, arg_one, *args, **kwargs):
         self.log(value, {"log_code": arg_one, "message": message}, **g_log_extra_kwargs, **kwargs)
 
     # Otherwise, treat arg_one as the message
+    # NOTE: We perform the string interpolation here so that incorrectly passed
+    #   interpolation arguments will raise rather than being swallowed by the
+    #   logging package
     else:
-        self.log(value, arg_one, *args, **g_log_extra_kwargs, **kwargs)
+        message = arg_one % args
+        self.log(value, message, **g_log_extra_kwargs, **kwargs)
 
 def _add_level_fn(name, value):
     logging.addLevelName(value, name.upper())

--- a/src/python/tests/test_alog.py
+++ b/src/python/tests/test_alog.py
@@ -24,6 +24,7 @@
 '''ALog unit tests.
 '''
 
+# Standard
 import inspect
 import io
 import json
@@ -35,6 +36,9 @@ import sys
 import threading
 import time
 import unittest
+
+# Third Party
+import pytest
 
 # Import the implementation details so that we can test them
 import alog.alog as alog
@@ -444,6 +448,22 @@ class TestLogCode(unittest.TestCase):
         self.assertEqual(record['log_code'], test_code)
         self.assertIn('message', record)
         self.assertEqual(record['message'], 'This is a test')
+
+    def test_formatting_error_with_and_without_log_code(self):
+        '''Test that a TypeError is raised when lazy log interpolation is used
+        both with and without a log code as the first argument
+        '''
+        alog.configure('info', formatter='pretty')
+        test_channel = alog.use_channel('TEST')
+        with pytest.raises(TypeError):
+            test_channel.info("<ABC12345I>", "HELLO %s", "WORLD", "FOO")
+        with pytest.raises(TypeError):
+            test_channel.info("<ABC12345I>", "HELLO %s %s", "WORLD")
+        with pytest.raises(TypeError):
+            test_channel.info("HELLO %s", "WORLD", "FOO")
+        with pytest.raises(TypeError):
+            test_channel.info("HELLO %s %s", "WORLD")
+
 
 class TestScopedLoggers(unittest.TestCase):
     def test_context_managed_scoping(self):


### PR DESCRIPTION
## Description

This PR fixes the mismatched behavior between having log codes and not having log codes w.r.t. raising errors for bad numbers of lazy log interpolation arguments.

## Changes

* Perform the string interpolation outside of the core `Logger.log` function when no log code present

## Testing

* Added a PR that failed without the fix

## Related Issue(s)

#163 
