### PR TITLE
Add alog extension tip py

### DIFF
--- a/src/python/README.md
+++ b/src/python/README.md
@@ -186,3 +186,6 @@ foo()
 2021-07-29T19:19:47.468428 [DEMO :DBUG] This is a test
 2021-07-29T19:19:48.471788 [DEMO :TRCE] 0:00:01.003284
 ```
+
+## Tip
+- Visual Studio Code (VSCode) users can take advantage of [alchemy-logging extension](https://marketplace.visualstudio.com/items?itemName=Gaurav-Kumbhat.alog-code-generator) that provides automatic random log code generation and insertion.

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -188,4 +188,4 @@ foo()
 ```
 
 ## Tip
-- Visual Studio Code (VSCode) users can take advantage of [alchemy-logging extension](https://marketplace.visualstudio.com/items?itemName=Gaurav-Kumbhat.alog-code-generator) that provides automatic random log code generation and insertion.
+- Visual Studio Code (VSCode) users can take advantage of [alchemy-logging extension](https://marketplace.visualstudio.com/items?itemName=Gaurav-Kumbhat.alog-code-generator) that provides automatic log code generation and insertion.


### PR DESCRIPTION
## Description

Add alog code generation extension in readme for python.

## Changes

Update readme with vscode extension tip

## Testing

N/A

## Related Issue(s)

N/A
