### PR TITLE
🐛 fix json-function bug

### DIFF
--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -358,13 +358,14 @@ def _log_with_code_method_override(self, value, arg_one, *args, **kwargs):
         self.log(value, arg_one, **g_log_extra_kwargs, **kwargs)
 
     # If arg_one looks like a log code, use the first positional arg as message
+    # and format based on the other args
     elif is_log_code(arg_one):
         self.log(
             value,
             {
                 "log_code": arg_one,
-                "message": args[0],
-                "args": tuple(args[1:]) if len(args) > 1 else None,
+                "message": args[0] % args[1:],
+                "args": None,
             },
             **g_log_extra_kwargs,
             **kwargs,


### PR DESCRIPTION
Signed-off-by: prashantgupta24 <prashantgupta24@gmail.com>

## Description

This PR fixes the issue in which logging with a log code and modulo string formatting and json output was giving an error 

## Changes

Message field should format the arguments `args[0] % args[1:]` to handle modulo string formatting.

## Testing

Added couple of tests

## Related Issue(s)

Fix https://github.com/IBM/alchemy-logging/issues/238
