### PR TITLE
Add duration field to AlogJsonFormatter

### DIFF
--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -95,7 +95,7 @@ class AlogJsonFormatter(AlogFormatterBase):
     """
     _FIELDS_TO_PRINT = ['name', 'levelname', 'asctime', 'message',
                         'exc_text', 'region-id', 'org-id', 'tran-id',
-                        'watson-txn-id', 'channel']
+                        'watson-txn-id', 'channel', 'duration']
 
     def __init__(self):
         AlogFormatterBase.__init__(self)
@@ -735,10 +735,10 @@ class _TimedLogBase:
     def _end_timed_log(self):
         """Gets the end time and prints the end message for this timed logger.
         """
-        duration = str(timedelta(seconds=time.time() - self.start_time))
+        duration = timedelta(seconds=time.time() - self.start_time)
         fmt = self.format_str + "%s"
-        args = list(self.args) + [duration]
-        self.log_fn(fmt, *args)
+        args = list(self.args) + [str(duration)]
+        self.log_fn(fmt, *args, extra={"duration": duration.total_seconds()})
 
 # pylint: disable=too-few-public-methods
 class ScopedTimer(_TimedLogBase):

--- a/src/python/tests/test_alog.py
+++ b/src/python/tests/test_alog.py
@@ -628,6 +628,7 @@ def test_timed_logger_context_managed_timer():
     timed_message = timed_log['message']
     assert timed_message.startswith('timed: 0:')
     assert re.match(r'^timed: [0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9]+$', timed_message)
+    assert timed_log["duration"] > 0
 
 def test_timed_logger_scoped_timer():
     # Configure for log capture
@@ -651,6 +652,7 @@ def test_timed_logger_scoped_timer():
     timed_message = timed_log['message']
     assert timed_message.startswith('timed: 0:')
     assert re.match(r'^timed: [0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9]+$', timed_message)
+    assert timed_log["duration"] > 0
 
 def test_timed_logger_decorated_timer():
     # Configure for log capture
@@ -674,6 +676,7 @@ def test_timed_logger_decorated_timer():
     timed_message = timed_log['message']
     assert timed_message.startswith('timed: 0:')
     assert re.match(r'^timed: [0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9]+$', timed_message)
+    assert timed_log["duration"] > 0
 
 ## IsEnabled ###################################################################
 


### PR DESCRIPTION
## Changes

This PR adds a duration field for log records created using the _TimedLogBase like the timed_function decorator or ScopedTimer class. This makes it easier for log formats like the AlogJsonFormatter to print the duration of a function.

## Testing

I tested my changes using `pytest` and in an example application

## Related Issue(s)

List any issues related to this PR
