### PR TITLE
Use version ranges for python test deps

### DIFF
--- a/src/python/requirements_test.txt
+++ b/src/python/requirements_test.txt
@@ -1,2 +1,2 @@
-pytest==7.0.1
-pytest-cov==4.0.0
+pytest>=7.0.1,<8
+pytest-cov>=4.0.0,<5


### PR DESCRIPTION
## Description

Loosen the version ranges on the python implementation's `requirements_test.txt` so Dependabot can stop proposing breaking changes!