### PR TITLE
LoggingConfigScopes: Only indent/deindent scopes if g_alog_formatter set

### DIFF
--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -611,14 +611,16 @@ class _ScopedLogBase:
         if self.enabled:
             self.log_fn(scope_start_str + str(self.format_str), *self.args)
             global g_alog_formatter
-            g_alog_formatter.indent()
+            if g_alog_formatter:
+                g_alog_formatter.indent()
 
     def _end_scoped_log(self):
         """Log the end message for a scoped logger and decrement the indentor.
         """
         if self.enabled:
             global g_alog_formatter
-            g_alog_formatter.deindent()
+            if g_alog_formatter:
+                g_alog_formatter.deindent()
             self.log_fn(scope_end_str + str(self.format_str), *self.args)
 
 # pylint: disable=too-few-public-methods

--- a/src/python/tests/test_alog.py
+++ b/src/python/tests/test_alog.py
@@ -25,6 +25,7 @@
 '''
 
 # Standard
+from unittest import mock
 import inspect
 import io
 import json
@@ -35,9 +36,6 @@ import re
 import sys
 import threading
 import time
-
-# Third Party
-import pytest
 
 # Import the implementation details so that we can test them
 import alog.alog as alog
@@ -605,6 +603,20 @@ def test_scoped_logger_disabled_scope_indentation():
     record = logged_output[0]
     assert record['num_indent'] == 0
 
+def test_default_log_config_with_scope():
+    """The scoped loggers need to run cleanly when default configuration has
+    enabled a given logger, but alog.configure has not been called to set up the
+    extra alog state.
+    """
+    with mock.patch.object(alog, "g_alog_formatter", None):
+        log = alog.use_channel("test-channel-basic-config")
+        log.setLevel(logging.INFO)
+
+        @alog.logged_function(log.info)
+        def foo():
+            pass
+
+        foo()
 
 ## Timed Loggers ###############################################################
 


### PR DESCRIPTION
## Description

Closes #329 

## Changes

Check `g_alog_formatter` before using it in scoped loggers

## Testing

* Unit test with simulated fresh environment
