### PR TITLE
NumericLevels: Support getting level values from numeric representations

### DIFF
--- a/src/python/tests/test_alog.py
+++ b/src/python/tests/test_alog.py
@@ -33,9 +33,11 @@ import logging
 import os
 import pickle
 import re
-import sys
 import threading
 import time
+
+# Third Party
+import pytest
 
 # Import the implementation details so that we can test them
 import alog.alog as alog
@@ -237,6 +239,22 @@ def test_configure_formatter_with_filename():
     assert fname == expected_fname
     assert lineno == expected_lineno
     assert func_name == expected_function
+
+@pytest.mark.parametrize(
+    'configure_kwargs',
+    [
+        {'default_level': 14},
+        {'default_level': '14'},
+        {'default_level': 'info', 'filters': 'FOO:14'},
+    ],
+)
+def test_configure_numeric_levels(configure_kwargs):
+    '''Test that a numeric value can be used to configure a level'''
+    alog.configure(**configure_kwargs)
+    ch = alog.use_channel('FOO')
+    assert ch.isEnabled('trace')
+    assert not ch.isEnabled('debug1')
+
 
 ## json ########################################################################
 


### PR DESCRIPTION
## Description

Adds support for specifying level values as integers

## Changes

* Introduce the detail function `_get_level_value` which will try to parse the level from an `int` if not found in the map
* Use `_get_level_value` everywhere `g_alog_name_to_level` was previously used to get a level value

## Testing

* Existing unit tests still pass
* New unit test for new ways of configuring

## Related Issue(s)

Closes: https://github.com/IBM/alchemy-logging/issues/370