### PR TITLE
A log logger protocol protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.coverage
+build/**
+*.egg-info
+.tox/**

--- a/src/python/CONTRIBUTING.md
+++ b/src/python/CONTRIBUTING.md
@@ -7,7 +7,7 @@ For general contribution practices, please refer to [the overall project CONTRIB
 You can run the unit tests as follows:
 
 ```sh
-# One-time setup to get the development environmet set up
+# One-time setup to get the development environment set up
 PYTHON_RELEASE_VERSION=0.0.0 python setup.py develop
 
 # Run the tests

--- a/src/python/alog/__init__.py
+++ b/src/python/alog/__init__.py
@@ -43,6 +43,4 @@ from .alog import (
 # Exposed details
 from .alog import g_alog_level_to_name as _level_to_name
 from .alog import g_alog_level_to_name as _name_to_level
-from .alog import AlogFormatterBase
-from .alog import AlogPrettyFormatter
-from .alog import AlogJsonFormatter
+from .protocols import ALogLoggerProtocol

--- a/src/python/alog/__init__.py
+++ b/src/python/alog/__init__.py
@@ -24,7 +24,21 @@
 """Alchemy Logging in python"""
 
 # Core components
-from .alog import configure, use_channel, ScopedLog, ContextLog, FnLog, FunctionLog, logged_function, ScopedTimer, ContextTimer, timed_function
+from .alog import (
+    AlogFormatterBase,
+    AlogJsonFormatter,
+    AlogPrettyFormatter,
+    ContextLog,
+    ContextTimer,
+    FnLog,
+    FunctionLog,
+    ScopedLog,
+    ScopedTimer,
+    configure,
+    logged_function,
+    timed_function,
+    use_channel,
+)
 
 # Exposed details
 from .alog import g_alog_level_to_name as _level_to_name

--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -397,7 +397,7 @@ def _get_level_value(level_name: _Level) -> Optional[int]:
 
 
 def _log_with_code_method_override(
-    self: logging.Logger, value: int, arg_one, *args, **kwargs
+    self: logging.Logger, value: int, arg_one: object, *args: object, **kwargs
 ) -> None:
     """This helper is used as an override to the native logging.Logger instance
     methods for each level. As such, it's first argument, self, is the logger
@@ -523,9 +523,9 @@ def _parse_str_of_filters(filters: str) -> Dict[str, _Level]:
 ## Import-time Setup ###########################################################
 
 # Add custom low levels
-for level, name in g_alog_level_to_name.items():
-    if name not in ["off", "notset"]:
-        _add_level_fn(name, level)
+for log_level, log_level_name in g_alog_level_to_name.items():
+    if log_level_name not in ["off", "notset"]:
+        _add_level_fn(log_level_name, log_level)
 
 # Patch over isEnabledFor to support level names
 _add_is_enabled()

--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -34,9 +34,12 @@ import threading
 import time
 import traceback
 from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
 
-_Level = Union[int, str]
+if TYPE_CHECKING:
+    from logging import _Level
+
+    from .protocols import ALogLoggerProtocol
 
 ## Formatters ##################################################################
 
@@ -641,7 +644,7 @@ def configure(
     g_filtered_channels = list(parsed_filters.keys())
 
 
-def use_channel(channel: Optional[str]) -> logging.Logger:
+def use_channel(channel: Optional[str]) -> "ALogLoggerProtocol":
     """Interface wrapper for python alog implementation to keep consistency with
     other languages.
     """

--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -37,9 +37,9 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
 
 if TYPE_CHECKING:
-    from logging import _Level
-
     from .protocols import ALogLoggerProtocol
+
+_Level = Union[int, str]
 
 ## Formatters ##################################################################
 
@@ -648,7 +648,8 @@ def use_channel(channel: Optional[str]) -> "ALogLoggerProtocol":
     """Interface wrapper for python alog implementation to keep consistency with
     other languages.
     """
-    return logging.getLogger(channel)
+    logger: "ALogLoggerProtocol" = logging.getLogger(channel)  # type: ignore
+    return logger
 
 
 ## Scoped Loggers ##############################################################

--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -224,7 +224,7 @@ class AlogPrettyFormatter(AlogFormatterBase):
         # Get the padded or truncated channel
         chan = channel
         if len(channel) > self.channel_len:
-            chan = channel[:self.channel_len]
+            chan = channel[: self.channel_len]
 
         elif len(channel) < self.channel_len:
             chan = channel + " " * (self.channel_len - len(channel))

--- a/src/python/alog/protocols.py
+++ b/src/python/alog/protocols.py
@@ -1,0 +1,257 @@
+import sys
+from typing import TYPE_CHECKING, ClassVar, Mapping, Optional, Protocol
+
+if TYPE_CHECKING:
+    from logging import (
+        Handler,
+        Logger,
+        LogRecord,
+        Manager,
+        RootLogger,
+        _ArgsType,
+        _ExcInfoType,
+        _Level,
+        _SysExcInfoType,
+    )
+
+    from typing_extensions import Self
+
+
+class LoggerProtocol(Protocol):
+    name: str  # undocumented
+    level: int  # undocumented
+    parent: Optional["Logger"]  # undocumented
+    propagate: bool
+    handlers: list["Handler"]  # undocumented
+    disabled: bool  # undocumented
+    root: ClassVar["RootLogger"]  # undocumented
+    manager: "Manager"  # undocumented
+
+    def __init__(self, name: str, level: "_Level" = 0) -> None:
+        ...
+
+    def setLevel(self, level: "_Level") -> None:
+        ...
+
+    def isEnabledFor(self, level: int) -> bool:
+        ...
+
+    def getEffectiveLevel(self) -> int:
+        ...
+
+    def getChild(self, suffix: str) -> "Self":
+        ...  # see python/typing#980
+
+    if sys.version_info >= (3, 12):
+
+        def getChildren(self) -> set["Logger"]:
+            ...
+
+    def debug(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def info(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def warning(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def warn(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def error(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def exception(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = True,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def critical(
+        self,
+        msg: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def log(
+        self,
+        level: int,
+        msg: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def _log(
+        self,
+        level: int,
+        msg: object,
+        args: "_ArgsType",
+        exc_info: Optional["_ExcInfoType"] = None,
+        extra: Optional[Mapping[str, object]] = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+    ) -> None:
+        ...  # undocumented
+
+    fatal = critical
+
+    def addHandler(self, hdlr: "Handler") -> None:
+        ...
+
+    def removeHandler(self, hdlr: "Handler") -> None:
+        ...
+
+    def findCaller(
+        self, stack_info: bool = False, stacklevel: int = 1
+    ) -> tuple[str, int, str, Optional[str]]:
+        ...
+
+    def handle(self, record: "LogRecord") -> None:
+        ...
+
+    def makeRecord(
+        self,
+        name: str,
+        level: int,
+        fn: str,
+        lno: int,
+        msg: object,
+        args: "_ArgsType",
+        exc_info: Optional["_SysExcInfoType"],
+        func: Optional[str] = None,
+        extra: Optional[Mapping[str, object]] = None,
+        sinfo: Optional[str] = None,
+    ) -> "LogRecord":
+        ...
+
+    def hasHandlers(self) -> bool:
+        ...
+
+    def callHandlers(self, record: "LogRecord") -> None:
+        ...  # undocumented
+
+
+class ALogLoggerProtocol(LoggerProtocol):
+    def is_enabled(self, level: "_Level") -> bool:
+        ...
+
+    def off(
+        self,
+        arg_one: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def trace(
+        self,
+        arg_one: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def debug1(
+        self,
+        arg_one: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def debug2(
+        self,
+        arg_one: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def debug3(
+        self,
+        arg_one: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...
+
+    def debug4(
+        self,
+        arg_one: object,
+        *args: object,
+        exc_info: "_ExcInfoType" = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        ...

--- a/src/python/alog/protocols.py
+++ b/src/python/alog/protocols.py
@@ -1,5 +1,34 @@
+################################################################################
+# MIT License
+#
+# Copyright (c) 2021 IBM
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+################################################################################
+"""Protocols to assist IDEs with code completion for the additional methods which
+Alchemy Logger overrides on the logging.Logger instances.
+"""
+
 import sys
-from typing import TYPE_CHECKING, ClassVar, Mapping, Optional, Protocol
+from typing import TYPE_CHECKING, ClassVar, List, Mapping, Optional, Protocol
+
+from .alog import _Level
 
 if TYPE_CHECKING:
     from logging import (
@@ -10,7 +39,6 @@ if TYPE_CHECKING:
         RootLogger,
         _ArgsType,
         _ExcInfoType,
-        _Level,
         _SysExcInfoType,
     )
 
@@ -18,34 +46,63 @@ if TYPE_CHECKING:
 
 
 class LoggerProtocol(Protocol):
+    """
+    A Protocol reflecting the public methods, type hints and docstrings of the stdlib
+    `logging.Logger`
+    """
+
     name: str  # undocumented
     level: int  # undocumented
     parent: Optional["Logger"]  # undocumented
     propagate: bool
-    handlers: list["Handler"]  # undocumented
+    handlers: List["Handler"]  # undocumented
     disabled: bool  # undocumented
     root: ClassVar["RootLogger"]  # undocumented
     manager: "Manager"  # undocumented
 
     def __init__(self, name: str, level: "_Level" = 0) -> None:
-        ...
+        """
+        Initialize the logger with a name and an optional level.
+        """
 
     def setLevel(self, level: "_Level") -> None:
-        ...
+        """
+        Set the logging level of this logger.  level must be an int or a str.
+        """
 
-    def isEnabledFor(self, level: int) -> bool:
-        ...
+    def isEnabledFor(self, level: int) -> bool:  # type: ignore
+        """
+        Is this logger enabled for level 'level'?
+        """
 
-    def getEffectiveLevel(self) -> int:
-        ...
+    def getEffectiveLevel(self) -> int:  # type: ignore
+        """
+        Get the effective level for this logger.
 
-    def getChild(self, suffix: str) -> "Self":
-        ...  # see python/typing#980
+        Loop through this logger and its parents in the logger hierarchy,
+        looking for a non-zero logging level. Return the first one found.
+        """
+
+    def getChild(self, suffix: str) -> "Self":  # type: ignore
+        """
+        Get a logger which is a descendant to this one.
+
+        This is a convenience method, such that
+
+        logging.getLogger('abc').getChild('def.ghi')
+
+        is the same as
+
+        logging.getLogger('abc.def.ghi')
+
+        It's useful, for example, when the parent logger is named using
+        __name__ rather than a literal string.
+        """
+        # see python/typing#980
 
     if sys.version_info >= (3, 12):
 
-        def getChildren(self) -> set["Logger"]:
-            ...
+        def getChildren(self) -> set["Logger"]: ...
 
     def debug(
         self,
@@ -56,7 +113,14 @@ class LoggerProtocol(Protocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with severity 'DEBUG'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.debug("Houston, we have a %s", "thorny problem", exc_info=1)
+        """
 
     def info(
         self,
@@ -67,7 +131,14 @@ class LoggerProtocol(Protocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with severity 'INFO'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.info("Houston, we have a %s", "interesting problem", exc_info=1)
+        """
 
     def warning(
         self,
@@ -78,7 +149,14 @@ class LoggerProtocol(Protocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with severity 'WARNING'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.warning("Houston, we have a %s", "bit of a problem", exc_info=1)
+        """
 
     def warn(
         self,
@@ -89,7 +167,9 @@ class LoggerProtocol(Protocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        The 'warn' method is deprecated, use 'warning' instead.
+        """
 
     def error(
         self,
@@ -100,7 +180,14 @@ class LoggerProtocol(Protocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with severity 'ERROR'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.error("Houston, we have a %s", "major problem", exc_info=1)
+        """
 
     def exception(
         self,
@@ -111,7 +198,9 @@ class LoggerProtocol(Protocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Convenience method for logging an ERROR with exception information.
+        """
 
     def critical(
         self,
@@ -122,7 +211,14 @@ class LoggerProtocol(Protocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with severity 'CRITICAL'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.critical("Houston, we have a %s", "major disaster", exc_info=1)
+        """
 
     def log(
         self,
@@ -134,7 +230,14 @@ class LoggerProtocol(Protocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with the integer severity 'level'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.log(level, "We have a %s", "mysterious problem", exc_info=1)
+        """
 
     def _log(
         self,
@@ -146,23 +249,38 @@ class LoggerProtocol(Protocol):
         stack_info: bool = False,
         stacklevel: int = 1,
     ) -> None:
-        ...  # undocumented
+        """
+        Low-level logging routine which creates a LogRecord and then calls
+        all the handlers of this logger to handle the record.
+        """
 
     fatal = critical
 
     def addHandler(self, hdlr: "Handler") -> None:
-        ...
+        """
+        Add the specified handler to this logger.
+        """
 
     def removeHandler(self, hdlr: "Handler") -> None:
-        ...
+        """
+        Remove the specified handler from this logger.
+        """
 
     def findCaller(
         self, stack_info: bool = False, stacklevel: int = 1
-    ) -> tuple[str, int, str, Optional[str]]:
-        ...
+    ) -> tuple[str, int, str, Optional[str]]:  # type: ignore
+        """
+        Find the stack frame of the caller so that we can note the source
+        file name, line number and function name.
+        """
 
     def handle(self, record: "LogRecord") -> None:
-        ...
+        """
+        Call the handlers for the specified record.
+
+        This method is used for unpickled records received from a socket, as
+        well as those created locally. Logger-level filtering is applied.
+        """
 
     def makeRecord(
         self,
@@ -176,19 +294,47 @@ class LoggerProtocol(Protocol):
         func: Optional[str] = None,
         extra: Optional[Mapping[str, object]] = None,
         sinfo: Optional[str] = None,
-    ) -> "LogRecord":
-        ...
+    ) -> "LogRecord":  # type: ignore
+        """
+        A factory method which can be overridden in subclasses to create
+        specialized LogRecords.
+        """
 
-    def hasHandlers(self) -> bool:
-        ...
+    def hasHandlers(self) -> bool:  # type: ignore
+        """
+        See if this logger has any handlers configured.
+
+        Loop through all handlers for this logger and its parents in the
+        logger hierarchy. Return True if a handler was found, else False.
+        Stop searching up the hierarchy whenever a logger with the "propagate"
+        attribute set to zero is found - that will be the last logger which
+        is checked for the existence of handlers.
+        """
 
     def callHandlers(self, record: "LogRecord") -> None:
-        ...  # undocumented
+        """
+        Pass a record to all relevant handlers.
+
+        Loop through all handlers for this logger and its parents in the
+        logger hierarchy. If no handler was found, output a one-off error
+        message to sys.stderr. Stop searching up the hierarchy whenever a
+        logger with the "propagate" attribute set to zero is found - that
+        will be the last logger whose handlers are called.
+        """
 
 
 class ALogLoggerProtocol(LoggerProtocol):
-    def is_enabled(self, level: "_Level") -> bool:
-        ...
+    """
+    A Protocol which describes the alchemy logging methods which it adds onto the
+    stdlib `logging.Logger` instances.
+    """
+
+    def isEnabled(self, level: "_Level") -> bool:  # type: ignore
+        """
+        Is this logger enabled for level 'level'?
+
+        Also supports referencing the level by name.
+        """
 
     def off(
         self,
@@ -199,7 +345,9 @@ class ALogLoggerProtocol(LoggerProtocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Disable the given channel completely.
+        """
 
     def trace(
         self,
@@ -210,7 +358,16 @@ class ALogLoggerProtocol(LoggerProtocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with severity 'TRCE' (an alchemy Logging custom level).
+
+        Used to log begin/end of functions for debugging code paths.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.trace("Houston, we have a %s", "major disaster", exc_info=1)
+        """
 
     def debug1(
         self,
@@ -221,7 +378,16 @@ class ALogLoggerProtocol(LoggerProtocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with severity 'DBG1' (an alchemy Logging custom level).
+
+        High-level debugging statements.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.debug1("Houston, we have a %s", "thorny problem", exc_info=1)
+        """
 
     def debug2(
         self,
@@ -232,7 +398,16 @@ class ALogLoggerProtocol(LoggerProtocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with severity 'DBG2' (an alchemy Logging custom level).
+
+        Mid-level debugging statements such as computed values.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.debug2("Houston, we have a %s", "thorny problem", exc_info=1)
+        """
 
     def debug3(
         self,
@@ -243,7 +418,16 @@ class ALogLoggerProtocol(LoggerProtocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with severity 'DBG3' (an alchemy Logging custom level).
+
+        Low-level debugging statements such as computed values inside loops.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.debug3("Houston, we have a %s", "thorny problem", exc_info=1)
+        """
 
     def debug4(
         self,
@@ -254,4 +438,14 @@ class ALogLoggerProtocol(LoggerProtocol):
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
     ) -> None:
-        ...
+        """
+        Log 'msg % args' with severity 'DBG4' (an alchemy Logging custom level).
+
+        Ultra-low-level debugging statements such as data dumps and/or statements
+        inside multiple nested loops.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.debug4("Houston, we have a %s", "thorny problem", exc_info=1)
+        """

--- a/src/python/alog/protocols.py
+++ b/src/python/alog/protocols.py
@@ -26,7 +26,19 @@ Alchemy Logger overrides on the logging.Logger instances.
 """
 
 import sys
-from typing import TYPE_CHECKING, ClassVar, List, Mapping, Optional, Protocol
+from logging import Filter, LogRecord
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    ClassVar,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    Set,
+    Tuple,
+    Union,
+)
 
 from .alog import _Level
 
@@ -34,7 +46,6 @@ if TYPE_CHECKING:
     from logging import (
         Handler,
         Logger,
-        LogRecord,
         Manager,
         RootLogger,
         _ArgsType,
@@ -45,7 +56,79 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
-class LoggerProtocol(Protocol):
+class _SupportsFilter(Protocol):
+    def filter(self, __record: LogRecord) -> bool: ...
+
+
+_FilterType = Union[Filter, Callable[[LogRecord], bool], _SupportsFilter]
+
+
+class FilterProtocol(Protocol):
+    """
+    A base class for loggers and handlers which allows them to share
+    common code.
+    """
+
+    filters: List[_FilterType]
+
+    def __init__(self) -> None:
+        """
+        Initialize the list of filters to be an empty list.
+        """
+
+    def addFilter(self, filter: _FilterType) -> None:  # pylint: disable=invalid-name
+        """
+        Add the specified filter to this handler.
+        """
+
+    def removeFilter(self, filter: _FilterType) -> None:  # pylint: disable=invalid-name
+        """
+        Remove the specified filter from this handler.
+        """
+
+    def filter(self, record: LogRecord) -> bool:  # type: ignore
+        """
+        Determine if a record is loggable by consulting all the filters.
+
+        The default is to allow the record to be logged; any filter can veto
+        this and the record is then dropped. Returns a zero value if a record
+        is to be dropped, else non-zero.
+
+        .. versionchanged:: 3.2
+
+           Allow filters to be just callables.
+        """
+
+    if sys.version_info >= (3, 12):
+
+        def filter(self, record: LogRecord) -> Union[bool, LogRecord]:  # type: ignore pylint: disable=function-redefined
+            """
+            Determine if a record is loggable by consulting all the filters.
+
+            The default is to allow the record to be logged; any filter can veto
+            this by returning a false value.
+            If a filter attached to a handler returns a log record instance,
+            then that instance is used in place of the original log record in
+            any further processing of the event by that handler.
+            If a filter returns any other true value, the original log record
+            is used in any further processing of the event by that handler.
+
+            If none of the filters return false values, this method returns
+            a log record.
+            If any of the filters return a false value, this method returns
+            a false value.
+
+            .. versionchanged:: 3.2
+
+               Allow filters to be just callables.
+
+            .. versionchanged:: 3.12
+               Allow filters to return a LogRecord instead of
+               modifying it in place.
+            """
+
+
+class LoggerProtocol(FilterProtocol):
     """
     A Protocol reflecting the public methods, type hints and docstrings of the stdlib
     `logging.Logger`
@@ -65,17 +148,17 @@ class LoggerProtocol(Protocol):
         Initialize the logger with a name and an optional level.
         """
 
-    def setLevel(self, level: "_Level") -> None:
+    def setLevel(self, level: "_Level") -> None:  # pylint: disable=invalid-name
         """
         Set the logging level of this logger.  level must be an int or a str.
         """
 
-    def isEnabledFor(self, level: int) -> bool:  # type: ignore
+    def isEnabledFor(self, level: int) -> bool:  # type: ignore pylint: disable=invalid-name
         """
         Is this logger enabled for level 'level'?
         """
 
-    def getEffectiveLevel(self) -> int:  # type: ignore
+    def getEffectiveLevel(self) -> int:  # type: ignore pylint: disable=invalid-name
         """
         Get the effective level for this logger.
 
@@ -83,7 +166,7 @@ class LoggerProtocol(Protocol):
         looking for a non-zero logging level. Return the first one found.
         """
 
-    def getChild(self, suffix: str) -> "Self":  # type: ignore
+    def getChild(self, suffix: str) -> "Self":  # type: ignore pylint: disable=invalid-name
         """
         Get a logger which is a descendant to this one.
 
@@ -102,8 +185,11 @@ class LoggerProtocol(Protocol):
 
     if sys.version_info >= (3, 12):
 
-        def getChildren(self) -> set["Logger"]: ...
+        def getChildren(self) -> Set["Logger"]:  # pylint: disable=invalid-name
+            ...
 
+    # Aligned with the typeshed type definition:
+    # `*kwargs` replaced with: `exc_info`, `stack_info`, `stacklevel`, `extra`
     def debug(
         self,
         msg: object,
@@ -122,6 +208,8 @@ class LoggerProtocol(Protocol):
         logger.debug("Houston, we have a %s", "thorny problem", exc_info=1)
         """
 
+    # Aligned with the typeshed type definition:
+    # `*kwargs` replaced with: `exc_info`, `stack_info`, `stacklevel`, `extra`
     def info(
         self,
         msg: object,
@@ -140,6 +228,18 @@ class LoggerProtocol(Protocol):
         logger.info("Houston, we have a %s", "interesting problem", exc_info=1)
         """
 
+    if sys.version_info >= (3, 12):
+        info.__doc__ = """
+        Log 'msg % args' with severity 'INFO'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.info("Houston, we have a %s", "notable problem", exc_info=1)
+        """
+
+    # Aligned with the typeshed type definition:
+    # `*kwargs` replaced with: `exc_info`, `stack_info`, `stacklevel`, `extra`
     def warning(
         self,
         msg: object,
@@ -158,7 +258,9 @@ class LoggerProtocol(Protocol):
         logger.warning("Houston, we have a %s", "bit of a problem", exc_info=1)
         """
 
-    def warn(
+    # Aligned with the typeshed type definition:
+    # `*kwargs` replaced with: `exc_info`, `stack_info`, `stacklevel`, `extra`
+    def warn(  # pylint: disable=invalid-name disable=missing-docstring
         self,
         msg: object,
         *args: object,
@@ -166,11 +268,10 @@ class LoggerProtocol(Protocol):
         stack_info: bool = False,
         stacklevel: int = 1,
         extra: Optional[Mapping[str, object]] = None,
-    ) -> None:
-        """
-        The 'warn' method is deprecated, use 'warning' instead.
-        """
+    ) -> None: ...
 
+    # Aligned with the typeshed type definition:
+    # `*kwargs` replaced with: `exc_info`, `stack_info`, `stacklevel`, `extra`
     def error(
         self,
         msg: object,
@@ -189,6 +290,8 @@ class LoggerProtocol(Protocol):
         logger.error("Houston, we have a %s", "major problem", exc_info=1)
         """
 
+    # Aligned with the typeshed type definition:
+    # `*kwargs` replaced with: `exc_info`, `stack_info`, `stacklevel`, `extra`
     def exception(
         self,
         msg: object,
@@ -202,6 +305,8 @@ class LoggerProtocol(Protocol):
         Convenience method for logging an ERROR with exception information.
         """
 
+    # Aligned with the typeshed type definition:
+    # `*kwargs` replaced with: `exc_info`, `stack_info`, `stacklevel`, `extra`
     def critical(
         self,
         msg: object,
@@ -220,6 +325,8 @@ class LoggerProtocol(Protocol):
         logger.critical("Houston, we have a %s", "major disaster", exc_info=1)
         """
 
+    # Aligned with the typeshed type definition:
+    # `*kwargs` replaced with: `exc_info`, `stack_info`, `stacklevel`, `extra`
     def log(
         self,
         level: int,
@@ -255,20 +362,34 @@ class LoggerProtocol(Protocol):
         """
 
     fatal = critical
+    if sys.version_info >= (3, 10):
 
-    def addHandler(self, hdlr: "Handler") -> None:
+        def fatal(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: "_ExcInfoType" = None,
+            stack_info: bool = False,
+            stacklevel: int = 1,
+            extra: Optional[Mapping[str, object]] = None,
+        ) -> None:
+            """
+            Don't use this method, use critical() instead.
+            """
+
+    def addHandler(self, hdlr: "Handler") -> None:  # pylint: disable=invalid-name
         """
         Add the specified handler to this logger.
         """
 
-    def removeHandler(self, hdlr: "Handler") -> None:
+    def removeHandler(self, hdlr: "Handler") -> None:  # pylint: disable=invalid-name
         """
         Remove the specified handler from this logger.
         """
 
-    def findCaller(
+    def findCaller(  # pylint: disable=invalid-name
         self, stack_info: bool = False, stacklevel: int = 1
-    ) -> tuple[str, int, str, Optional[str]]:  # type: ignore
+    ) -> Tuple[str, int, str, Optional[str]]:  # type: ignore
         """
         Find the stack frame of the caller so that we can note the source
         file name, line number and function name.
@@ -282,7 +403,7 @@ class LoggerProtocol(Protocol):
         well as those created locally. Logger-level filtering is applied.
         """
 
-    def makeRecord(
+    def makeRecord(  # pylint: disable=invalid-name
         self,
         name: str,
         level: int,
@@ -300,7 +421,7 @@ class LoggerProtocol(Protocol):
         specialized LogRecords.
         """
 
-    def hasHandlers(self) -> bool:  # type: ignore
+    def hasHandlers(self) -> bool:  # type: ignore pylint: disable=invalid-name
         """
         See if this logger has any handlers configured.
 
@@ -311,7 +432,7 @@ class LoggerProtocol(Protocol):
         is checked for the existence of handlers.
         """
 
-    def callHandlers(self, record: "LogRecord") -> None:
+    def callHandlers(self, record: "LogRecord") -> None:  # pylint: disable=invalid-name
         """
         Pass a record to all relevant handlers.
 
@@ -329,7 +450,7 @@ class ALogLoggerProtocol(LoggerProtocol):
     stdlib `logging.Logger` instances.
     """
 
-    def isEnabled(self, level: "_Level") -> bool:  # type: ignore
+    def isEnabled(self, level: "_Level") -> bool:  # type: ignore pylint: disable=invalid-name
         """
         Is this logger enabled for level 'level'?
 

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -1,0 +1,25 @@
+# Alog overrides methods on `logging.Logger`.
+# Pytest alters the order of imports, resulting in `alog` overriding information prior to
+# us being able to make a copy of it.
+#
+
+# conftest.py is read before individual tests (to allow for fixtures to be shared across files).
+# We make use of this priority to give us a chance to capture the original method names,
+# docstrings and method parameters of stdlib `logging.Logger` prior to the import of `alog`
+# which overrides them
+import inspect
+from logging import Logger
+from typing import List
+
+
+def get_parameter_names(obj: object, method_name: str) -> List[str]:
+    """
+    Get the parameter names for an object's method
+    """
+    signature = inspect.signature(getattr(obj, method_name))
+    return list(signature.parameters)
+
+
+LOGGER_FUNCTIONS = {fn[0] for fn in inspect.getmembers(Logger, inspect.isfunction)}
+LOGGER_DOCSTRINGS = {fn: inspect.getdoc(getattr(Logger, fn)) for fn in LOGGER_FUNCTIONS}
+LOGGER_PARAMETERS = {fn: get_parameter_names(Logger, fn) for fn in LOGGER_FUNCTIONS}

--- a/src/python/tests/test_protocols.py
+++ b/src/python/tests/test_protocols.py
@@ -1,0 +1,101 @@
+################################################################################
+# MIT License
+#
+# Copyright (c) 2021 IBM
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+################################################################################
+"""ALog unit tests to confirm that the protocol is aligned `logging.Logger`."""
+
+import inspect
+
+from alog.protocols import LoggerProtocol  # pylint: disable=wrong-import-position
+
+from tests.conftest import (
+    LOGGER_DOCSTRINGS,
+    LOGGER_FUNCTIONS,
+    LOGGER_PARAMETERS,
+    get_parameter_names,
+)
+
+PROTOCOL_FUNCTIONS = {
+    fn[0] for fn in inspect.getmembers(LoggerProtocol, inspect.isfunction)
+}
+PROTOCOL_DOCSTRINGS = {
+    fn: inspect.getdoc(getattr(LoggerProtocol, fn)) for fn in LOGGER_FUNCTIONS
+}
+PROTOCOL_PARAMETERS = {
+    fn: get_parameter_names(LoggerProtocol, fn) for fn in LOGGER_FUNCTIONS
+}
+
+
+def test_protocol_is_complete():
+    """
+    Test that all functions in stdlib `Logger` exists in the protocol `LoggerProtocol`
+    """
+    excluded_functions = {"__reduce__", "__repr__"}
+
+    fn_not_in_protocol = LOGGER_FUNCTIONS.difference(PROTOCOL_FUNCTIONS)
+    fn_not_in_protocol = fn_not_in_protocol.difference(excluded_functions)
+
+    assert not fn_not_in_protocol, "All Logger functions should exist in the protocol"
+
+
+def test_protocol_docstrings():
+    """
+    Test that all docstrings in `LoggerProtocol` matches those of the stdlib `Logger`
+    """
+    assert PROTOCOL_DOCSTRINGS == LOGGER_DOCSTRINGS
+
+
+def test_protocol_function_signatures():
+    """
+    Test that all function parameter names in `LoggerProtocol` matches those of the
+    stdlib `Logger`
+    """
+
+    # Adjust LOGGER_PARAMETERS for expected differences.
+    # These are aligned with the typeshed type definition where `*kwargs` is replaced
+    # with `exc_info`, `stack_info`, `stacklevel`, `extra`
+    param_list = {
+        "log",
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error",
+        "critical",
+        "fatal",
+    }
+    adjusted_logger_parameters = {}
+    for param in LOGGER_PARAMETERS:
+        params = [p for p in LOGGER_PARAMETERS[param]]
+        if param in param_list:
+            params.remove("kwargs")
+            params.extend(["exc_info", "stack_info", "stacklevel", "extra"])
+        elif param == "exception":
+            params.remove("kwargs")
+            params.extend(["stack_info", "stacklevel", "extra"])
+        adjusted_logger_parameters[param] = params
+
+    # Compare parameters against adjusted Logger parameters
+    assert PROTOCOL_PARAMETERS == adjusted_logger_parameters
+
+
+# Type annotations/hints aren't tested since those are included in the stdlib `Logger`

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+env_list = py{38,39,310,311,312}
+minversion = 4.14.1
+package_root = ./src/python
+
+[testenv]
+description = run the tests with pytest
+package = wheel
+wheel_build_env = .pkg
+deps =
+    pytest>=7.0.1,<9
+    pytest-cov>=4.0.0,<5
+commands =
+    pytest {tty:--color=yes}  {posargs: --cov=alog --cov=util --cov-report=term --cov-report=html}
+
+[testenv:.pkg]
+setenv =
+    PYTHON_RELEASE_VERSION = {env:PYTHON_RELEASE_VERSION:"0.0.0"}


### PR DESCRIPTION
## Description

Improve IDE code completion by adding the `ALogLoggerProtocol` protocol and type hints for `use_channel()`.
`ALogLoggerProtocol` contains the additional methods which `alog` adds to `logging.Logger`. `ALogLoggerProtocol` extends `LoggerProtocol`  and `FilterProtocol` reflects the stdlib signatures and docstrings.

## Changes

- Adds `ALogLoggerProtocol`
- Adds tox to test for all supported python versions

## Testing

`LoggerProtocol` is tested to confirm that the following components matches those of stdlib, where they are expected to match:

- Complete ito. the existence of the methods
- Docstrings
- Method signatures

## Related Issue(s)

Closes IBM/alchemy-logging#393
