### PR TITLE
TorchTraceConflict: 

### DIFF
--- a/src/python/tests/test_alog.py
+++ b/src/python/tests/test_alog.py
@@ -945,3 +945,12 @@ def test_bug_uvicorn_access_log(capsys):
     logger.info("One %s, Two %s", 1, 2)
     captured = str(capsys.readouterr().err)
     assert "--- Logging error ---" not in captured
+
+
+def test_stacklevel_provided():
+    '''Test that a logging statement which specifies stacklevel does not cause a
+    logging error
+    '''
+    alog.configure('debug')
+    log = alog.use_channel('FOO')
+    log.info('asdf', stacklevel=2)


### PR DESCRIPTION
## Description

Update logic for setting stacklevel to work with external values

## Changes

Update the logic to respect and augment other wrapper functions that set `stacklevel`

## Testing

Added a unit test that repros the conflict when torch explicitly sets `stacklevel`

## Related Issue(s)

Addresses #432 