### PR TITLE
Update Alog Petty Print to prepend Metadata

### DIFF
--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -272,8 +272,9 @@ class AlogPrettyFormatter(AlogFormatterBase):
             record.message = ""
         if metadata is not None and len(metadata) > 0:
             if len(record.message) > 0:
-                record.message += " "
-            record.message += json.dumps(metadata)
+                record.message = json.dumps(metadata)+" "+record.message
+            else:
+                record.message = json.dumps(metadata)
 
         level = record.levelname
         channel = record.name

--- a/src/python/alog/alog.py
+++ b/src/python/alog/alog.py
@@ -216,9 +216,10 @@ class AlogPrettyFormatter(AlogFormatterBase):
         "debug4": "DBG4",
     }
 
-    def __init__(self, channel_len=5) -> None:
+    def __init__(self, channel_len=5, include_metadata: bool = False) -> None:
         AlogFormatterBase.__init__(self)
         self.channel_len = channel_len
+        self.include_metadata = include_metadata
 
     def _make_header(
         self, timestamp: str, channel: str, level: str, log_code: Optional[str]
@@ -270,7 +271,7 @@ class AlogPrettyFormatter(AlogFormatterBase):
         # Add metadata if present
         if not hasattr(record, "message"):
             record.message = ""
-        if metadata is not None and len(metadata) > 0:
+        if self.include_metadata and metadata is not None and len(metadata) > 0:
             if len(record.message) > 0:
                 record.message = json.dumps(metadata)+" "+record.message
             else:


### PR DESCRIPTION
## Description

This PR updates the pretty print alog formatter to prepend the metadata instead of appending it e.g.:

```shell
2024-09-17T13:57:48.463604 [CHNL:INFO:123146149339136] <CRE00499128I>Processing has started {"id": "61515949-313b-49be-9f89-d71c38b22b3a"}
```
to
```shell
2024-09-17T13:57:48.463604 [CHNL:INFO:123146149339136] {"id": "61515949-313b-49be-9f89-d71c38b22b3a"} <CRE00499128I>Processing has started 
```

This makes it easier to read the message while retaining all of the metadata information

## Changes

What changes are included in this PR?

## Testing

How did you test this PR?

## Related Issue(s)

List any issues related to this PR
